### PR TITLE
add opt. sensor_model expected_rate and per_second

### DIFF
--- a/octomap_server/include/octomap_server/CallbackRate.h
+++ b/octomap_server/include/octomap_server/CallbackRate.h
@@ -1,0 +1,86 @@
+#ifndef OCTOMAP_SERVER_CALLBACK_RATE_H
+#define OCTOMAP_SERVER_CALLBACK_RATE_H
+
+#include <cmath>
+
+#include <octomap/octomap_utils.h>
+#include <ros/time.h>
+
+namespace octomap_server {
+
+class CallbackRate
+{
+public:
+  CallbackRate()
+  {
+    reset();
+  }
+
+  void reset()
+  {
+    n_ = 0;
+  }
+
+  void update()
+  {
+    ros::Time now = ros::Time::now();
+    if (n_ == 0)
+    {
+      last_time_ = now;
+    }
+    else
+    {
+      double delta_t = (now - last_time_).toSec();
+      if (n_ == 1)
+      {
+        delta_t_ema_ = delta_t;
+      }
+      else
+      {
+        if (delta_t > delta_t_invalid_factor_ * delta_t_ema_)
+        {
+          reset();
+          last_time_ = now;
+        }
+        else
+        {
+          delta_t_ema_ = delta_t * ema_alpha_ + delta_t_ema_ * (1.0 - ema_alpha_);
+        }
+      }
+    }
+    ++n_;
+  }
+
+  bool valid()
+  {
+    return n_ >= min_n_ && delta_t_ema_ > 0.0;
+  }
+
+  double getCurrentRate()
+  {
+    return 1.0 / delta_t_ema_;
+  }
+
+  bool rateIsApproximately(double expected_rate)
+  {
+    return valid() && std::abs(getCurrentRate() - expected_rate) < expected_rate * approximate_epsilon_;
+  }
+
+protected:
+  ros::Time last_time_;
+  size_t n_;
+  // Current delta_t exponential moving average
+  double delta_t_ema_;
+  // Alpha to use when calculating the exponential moving average
+  double ema_alpha_ = 0.05;
+  // Minimum number of samples before considering moving average valid.
+  double min_n_ = 20;
+  // If a delta_t of more than the factor times the current delta_t is encountered the EMA is reset.
+  double delta_t_invalid_factor_ = 5.0;
+  // What factor of the expected rate will be considered approximately equal to the tracked rate.
+  double approximate_epsilon_ = .2;
+};
+
+}  // namespace octomap_server
+
+#endif  // OCTOMAP_SERVER_CALLBACK_RATE_H

--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -76,6 +76,7 @@
 #endif
 
 #include <octomap_server/types.h>
+#include <octomap_server/CallbackRate.h>
 #include <octomap_server/PointCloudSynchronizer.h>
 #include <octomap_server/OcTreeStampedWithExpiry.h>
 #include <octomap_server/SensorUpdateKeyMap.h>
@@ -154,6 +155,7 @@ protected:
 
     int callback_id = m_callbackCounts.size();
     m_callbackCounts.push_back(0);
+    m_callbackRates.push_back(CallbackRate());
     std::vector<std::string> callback_topics;
     callback_topics.resize(4);
     callback_topics[0] = ground_topic;
@@ -334,6 +336,7 @@ protected:
   bool m_latchedTopics;
   int m_callbackSkipCount;
   std::vector<unsigned int> m_callbackCounts;
+  std::vector<CallbackRate> m_callbackRates;
   std::vector<std::vector<std::string>> m_callbackTopics;
   bool m_trackFreeSpace;
   bool m_publishFreeSpace;
@@ -347,6 +350,7 @@ protected:
   ros::Time m_publish3DMapUpdateLastTime;
   double m_publish2DPeriod;
   ros::Time m_publish2DLastTime;
+  double m_expectedSensorRate;
 
   double m_res;
   unsigned m_treeDepth;


### PR DESCRIPTION
Add optional parameters to the sensor_model, expected_rate, hit_per_second and miss_per_second. If the expected_rate is set, it is used when calculating the probability of a single hit or miss from the new hit_per_second and miss_per_second parameters. This makes it easier to parameterize by time and then to simply set the expected sensor update rate. Add a throttled warning if the sensor is not updating near the expected rate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/octomap_mapping/4)
<!-- Reviewable:end -->
