### PR TITLE
Optimize octomap server parameters

### DIFF
--- a/octomap_server_launch/salt_srv/pillar/default/truck/config/octomap_server_launch/octomap_servers.sls
+++ b/octomap_server_launch/salt_srv/pillar/default/truck/config/octomap_server_launch/octomap_servers.sls
@@ -68,9 +68,6 @@ configuration:
           octomap_server_node:
             publish_3d_map_period: 4.0
             publish_2d_period: 4.0
-            # Publish incremental octomap updates at up to 50Hz so new obstacles
-            # appear in the costmap within one sensor frame.
-            publish_3d_map_update_period: 0.02
             segmented_topics:
               - nonground_topic: "/lidars/top_front/segmentation/obstacle_cloud"
                 ground_topic: "/lidars/top_front/segmentation/floor_cloud"
@@ -118,9 +115,6 @@ configuration:
           octomap_server_node:
             publish_3d_map_period: 4.0
             publish_2d_period: 4.0
-            # Publish incremental octomap updates at up to 50Hz so new obstacles
-            # appear in the costmap within one sensor frame.
-            publish_3d_map_update_period: 0.02
             segmented_topics:
               - nonground_topic: "/lidars/corner_lidars/front_right/segmentation/obstacle_cloud"
                 sensor_origin_frame_id: "front_right_lidar_parallel_to_base"
@@ -143,6 +137,7 @@ configuration:
 
         low_cameras:
           octomap_server_node:
+            skip_count: 1
             publish_3d_map_period: 4.0
             publish_2d_period: 4.0
             segmented_topics:


### PR DESCRIPTION
publish_3d_map_update_period only gates delta serialization, not ray casting. At 10 Hz both top_front and corner_lidar sensors update no faster than the default publish period, so the 0.02 s override was doing nothing useful.

Add skip_count: 1 to low_cameras to halve ray-casting frequency for the dense depth camera point clouds, which costs CPU.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/octomap_mapping/7)
<!-- Reviewable:end -->
